### PR TITLE
Manifest: update to new release artifact

### DIFF
--- a/net.hhoney.tinycrate.yml
+++ b/net.hhoney.tinycrate.yml
@@ -22,7 +22,7 @@ modules:
 
   - type: file
     url: https://github.com/HarmonyHoney/tiny_crate/releases/download/2025.02.23/tinycrate-linux.pck
-    sha256: b0332e49bbc0d51f2d67ee74c0166c0915b1d7ea33fe52ff9e9fc55eb8b3feb7
+    sha256: ccf01fa100fe876e2a5d222f4cc7e60f57d2e09728f9948a188fa9ea4540d01b
 
   build-commands:
   - install -Dm644 tinycrate-linux.pck ${FLATPAK_DEST}/bin/godot-runner.pck


### PR DESCRIPTION
The PCK file was updated upstream (actually reverted, since the intended changes were just to packaging…) on the release; this corrects the sha256sum for that updated file.