### PR TITLE
Manifest: Add external data checker

### DIFF
--- a/net.hhoney.tinycrate.yml
+++ b/net.hhoney.tinycrate.yml
@@ -18,6 +18,11 @@ modules:
   - type: git
     url: https://github.com/HarmonyHoney/tiny_crate.git
     commit: 238d8db040d3be3764276b8b7eaebd5785996375
+    x-checker-data:
+      type: git
+      tag-pattern: "^([\\d.]+)$"
+      version-scheme: semantic
+      is-main-source: true
 
   - type: file
     url: https://github.com/HarmonyHoney/tiny_crate/releases/download/2025.03.03/Tiny-Crate.pck

--- a/net.hhoney.tinycrate.yml
+++ b/net.hhoney.tinycrate.yml
@@ -24,8 +24,8 @@ modules:
       tag-query: .tag_name
 
   - type: file
-    url: https://github.com/HarmonyHoney/tiny_crate/releases/download/2025.03.03/Tiny-Crate.pck
-    sha256: 0676a860b287c505ee6ca8da42f29141b6fa2b245c5eea684ce50f2d2e368c8f
+    url: https://github.com/HarmonyHoney/tiny_crate/releases/download/2025.03.03/tinycrate-linux.pck
+    sha256: ccf01fa100fe876e2a5d222f4cc7e60f57d2e09728f9948a188fa9ea4540d01b
     x-checker-data:
       type: json
       url: https://api.github.com/repos/HarmonyHoney/tiny_crate/releases/latest

--- a/net.hhoney.tinycrate.yml
+++ b/net.hhoney.tinycrate.yml
@@ -19,14 +19,18 @@ modules:
     url: https://github.com/HarmonyHoney/tiny_crate.git
     commit: 238d8db040d3be3764276b8b7eaebd5785996375
     x-checker-data:
-      type: git
-      tag-pattern: "^([\\d.]+)$"
-      version-scheme: semantic
-      is-main-source: true
+      type: json
+      url: https://api.github.com/repos/HarmonyHoney/tiny_crate/releases/latest
+      tag-query: .tag_name
 
   - type: file
     url: https://github.com/HarmonyHoney/tiny_crate/releases/download/2025.03.03/Tiny-Crate.pck
     sha256: 0676a860b287c505ee6ca8da42f29141b6fa2b245c5eea684ce50f2d2e368c8f
+    x-checker-data:
+      type: json
+      url: https://api.github.com/repos/HarmonyHoney/tiny_crate/releases/latest
+      version-query: .tag_name
+      url-query: .assets[] | select(.name=='tinycrate-linux.pck') | .browser_download_url
 
   build-commands:
   - install -Dm644 Tiny-Crate.pck ${FLATPAK_DEST}/bin/godot-runner.pck

--- a/net.hhoney.tinycrate.yml
+++ b/net.hhoney.tinycrate.yml
@@ -33,7 +33,7 @@ modules:
       url-query: .assets[] | select(.name=='tinycrate-linux.pck') | .browser_download_url
 
   build-commands:
-  - install -Dm644 Tiny-Crate.pck ${FLATPAK_DEST}/bin/godot-runner.pck
+  - install -Dm644 tinycrate-linux.pck ${FLATPAK_DEST}/bin/godot-runner.pck
   - install -Dm644 linux/${FLATPAK_ID}.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
   - install -Dm644 linux/${FLATPAK_ID}.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
   - install -Dm644 linux/${FLATPAK_ID}-symbolic.svg ${FLATPAK_DEST}/share/icons/hicolor/symbolic/apps/${FLATPAK_ID}-symbolic.svg


### PR DESCRIPTION
This adds [External Data Checker](https://docs.flathub.org/docs/for-app-authors/external-data-checker) support for the git sources and PCK export, based on the latest upstream release. Upstream releases should be automatically picked up and proposed as a PR by @flathubbot.

They will still need to be tested (using the automatically-built Flatpak) and merged by a human, but it should cut down on repetitive work.