### PR TITLE
Manifest: rename downloaded PCK file

### DIFF
--- a/net.hhoney.tinycrate.yml
+++ b/net.hhoney.tinycrate.yml
@@ -26,6 +26,7 @@ modules:
   - type: file
     url: https://github.com/HarmonyHoney/tiny_crate/releases/download/2025.03.03/tinycrate-linux.pck
     sha256: ccf01fa100fe876e2a5d222f4cc7e60f57d2e09728f9948a188fa9ea4540d01b
+    dest-filename: godot-runner.pck
     x-checker-data:
       type: json
       url: https://api.github.com/repos/HarmonyHoney/tiny_crate/releases/latest
@@ -33,7 +34,7 @@ modules:
       url-query: '"https://github.com/HarmonyHoney/tiny_crate/releases/download/" + $version + "/tinycrate-ci-" + $version + ".pck"'
 
   build-commands:
-  - install -Dm644 tinycrate-linux.pck ${FLATPAK_DEST}/bin/godot-runner.pck
+  - install -Dm644 godot-runner.pck ${FLATPAK_DEST}/bin/godot-runner.pck
   - install -Dm644 linux/${FLATPAK_ID}.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
   - install -Dm644 linux/${FLATPAK_ID}.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
   - install -Dm644 linux/${FLATPAK_ID}-symbolic.svg ${FLATPAK_DEST}/share/icons/hicolor/symbolic/apps/${FLATPAK_ID}-symbolic.svg


### PR DESCRIPTION
Should fix the error in #8 CI by giving us a consistent name for the download.